### PR TITLE
Adiciona código de conduta

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# OpenDevUFCG - Código de Conduta
+
+Este código de conduta vale para todos os projetos e encontros que a comunidade @OpenDevUFCG acolhe.
+
+## Nossa promessa
+
+Com o interesse de fomentar uma comunidade aberta e acolhedora,
+nós, como colaboradores e administradores deste projeto, comprometemo-nos
+a fazer a participação deste projeto uma experiência livre de assédio
+para todos, independentemente da aparência pessoal, deficiência,
+etnia, gênero, idade, identidade ou expressão de gênero, identidade
+ou orientação sexual, nacionalidade, nível de experiência, porte físico,
+raça ou religião.
+
+## Nossos padrões
+
+Exemplos de comportamentos que contribuem a criar um ambiente positivo incluem:
+
+* Usar linguagem acolhedora e inclusiva
+* Respeitar pontos de vista e experiências diferentes
+* Aceitar crítica construtiva com graça
+* Focar no que é melhor para a comunidade
+* Mostrar empatia com outros membros da comunidade
+
+Exemplos de comportamentos inaceitáveis por parte dos participantes incluem:
+
+* Uso de linguagem ou imagens sexuais e atenção ou avanço sexual indesejada
+* Comentários insultuosos e/ou depreciativos e ataques pessoais ou políticos (*Trolling*)
+* Assédio público ou privado
+* Publicar informação pessoal de outros sem permissão explícita, como, por exemplo, um endereço eletrônico ou residencial
+* Qualquer outra forma de conduta que pode ser razoavelmente considerada inapropriada num ambiente profissional
+
+## Nossas responsibilidades
+
+Os administradores do projeto são responsáveis por esclarecer os padrões de
+comportamento e deverão tomar ação corretiva apropriada e justa em resposta
+a qualquer instância de comportamento inaceitável.
+
+Os administradores do projeto têm o direito e a responsabilidade de
+remover, editar ou rejeitar comentários, commits, código, edições
+na wiki, erros ou outras formas de contribuição que não estejam de
+acordo com este Código de Conduta, bem como banir temporariamente ou
+permanentemente qualquer colaborador por qualquer outro comportamento
+que se considere impróprio, perigoso, ofensivo ou problemático.
+
+## Escopo
+
+Este código de Código de Conduta aplica-se para todos os projetos que a organização @OpenDevUFCG do github acolhe, ou qualquer outra presença online ou offline que possua iterações da comunidade, incluindo eventos e meetups.
+
+Este Código de Conduta também aplica-se dentro dos espaços do projeto ou
+qualquer espaço público onde alguém represente o mesmo ou a sua
+comunidade. Exemplos de representação do projeto ou comunidade incluem
+usar um endereço de email oficial do projeto, postar por uma conta de
+mídia social oficial, ou agir como um representante designado num evento
+online ou offline. A representação de um projeto pode ser ainda definida e
+esclarecida pelos administradores do projeto.
+
+## Aplicação
+
+Comportamento abusivo, de assédio ou de outros tipos pode ser
+comunicado contatando a equipe do projeto *thayanne.sousa@ccc.ufcg.edu.br*. Todas as queixas serão revistas e investigadas e
+resultarão numa resposta necessária e apropriada à situação.
+A equipe é obrigada a manter a confidencialidade em relação
+ao elemento que reportou o incidente. Demais detalhes de
+políticas de aplicação podem ser postadas separadamente.
+
+Administradores do projeto que não sigam ou não mantenham o Código
+de Conduta em boa fé podem enfrentar repercussões temporárias ou permanentes
+determinadas por outros membros da liderança do projeto.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org),
+versão 1.4, disponível em https://www.contributor-covenant.org/pt-br/version/1/4/code-of-conduct.html


### PR DESCRIPTION
Achei [esse](https://www.contributor-covenant.org/pt-br/version/1/4/code-of-conduct) código de conduta usado por maioria dos projetos open source perfeito e adequado para nossa comunidade. 

Adicionei apenas informações de email para quem reportar caso aja queixa e também que o código de conduta vale para todos os projetos da organização OpenDevUFCG


closes #4 