### PR TITLE
Adiciona nova endpoint pt-br do laguinho

### DIFF
--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -10,8 +10,8 @@ const getAxiosInstance = () => {
 };
 
 const requestGithub = async (after: string | any) => {
-    const response = await getAxiosInstance().get('/repositories', {
-        params: { after },
+    const response = await getAxiosInstance().get('/repositorios', {
+        params: { apos: after },
     });
     return response;
 };


### PR DESCRIPTION
O laguinho irá mudar as endpoints para pt-br aqui opendevufcg/laguinho-api#28, é necessário merjar essa pr junto, para o issueAi não quebrar em produção.

Apenas renomeei as endpoints e o parâmetro `after`, tudo continua o mesmo que antes.


Para testar:

1. Clone o laguinho
2. Sincronize a PR 28 do laguinho com `git fetch origin pull/28/head:pr-28`
3. `git checkout pr-28`
4. Rode o laguinho normalmente
5. No issueai, mude a url da api para `http://localhost:8080/v1/repositorios`, em `src/lib/github.js`
6. Teste se o issueai continua normal