### PR TITLE
Ajuste para exibição dos cards de repositorios

### DIFF
--- a/src/components/commons/repository/Repository.css
+++ b/src/components/commons/repository/Repository.css
@@ -51,7 +51,7 @@
 /* Extra large devices (large laptops and desktops, 1200px and up) */
 @media only screen and (min-width: 1200px) {
     .repository-grid {
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 
@@ -75,6 +75,7 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     background: #ffffff;
+    justify-items: center;
 }
 
 .repository-card:hover {
@@ -99,6 +100,7 @@ h3.repository-name {
     grid-area: description;
     color: #444444;
     letter-spacing: 0.7px;
+    text-align: justify;
 }
 
 .repository-stats {
@@ -106,6 +108,7 @@ h3.repository-name {
     display: flex;
     width: 100%;
     flex-wrap: wrap;
+    justify-content: space-around;
 }
 
 .stat {

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -11,7 +11,10 @@ const getAxiosInstance = () => {
 
 const requestGithub = async (after: string | any) => {
     const response = await getAxiosInstance().get('/repositorios', {
-        params: { apos: after },
+        params: {
+            apos: after,
+            quantidade: 6,
+        },
     });
     return response;
 };


### PR DESCRIPTION
<!-- Issue relacionada -->

#72

#### Qual o propósito dessa pull request?

Corrigir a exibição dos repositórios, para que sempre o grid esteja inteiramente preenchido.

#### O que foi feito?

Foi feita a alteração na requisição da api que retorna os repositorios, para sempre fazer a chamada retornando 6 registros, e alterado a quantidade de colunas a exibir para 3 em dispositivos com larguras de tela acima de 1200px, assim mesmo exibindo duas colunas ou até mesmo exibindo apenas uma coluna o grid sempre estará completo.

#### Tipo de mudanças

<!-- Marque com um 'x' os tipos de mudanças realizadas -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] Nova feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Requires change to documentation, which has been updated accordingly.
