### PR TITLE
Arrumar bug do botão 'Ver mais'

### DIFF
--- a/src/components/projects/ProjectsPage.js
+++ b/src/components/projects/ProjectsPage.js
@@ -11,12 +11,14 @@ type AppState = {
     repositoryList: Repository[],
     cursor: string | null,
     loading: boolean,
+    emptyRequest: boolean,
 };
 
 function updateListState(data: Repository[], cursor) {
     return (state: AppState) => ({
         repositoryList: [...state.repositoryList, ...data],
         cursor,
+        emptyRequest: !data.length,
     });
 }
 
@@ -25,6 +27,7 @@ export default class ProjectsPage extends React.Component<void, AppState> {
         repositoryList: [],
         cursor: null,
         loading: true,
+        emptyRequest: false,
     };
 
     componentDidMount() {
@@ -41,21 +44,23 @@ export default class ProjectsPage extends React.Component<void, AppState> {
     };
 
     render() {
-        const { repositoryList, loading } = this.state;
+        const { emptyRequest, repositoryList, loading } = this.state;
         return (
             <div>
                 <RepositoryGrid repositories={repositoryList} />
                 <div className="footer">
-                    <button
-                        type="button"
-                        className="show-more-btn"
-                        onClick={this.updateRepositoryList}>
-                        {loading ? (
-                            <img className="loader" alt="loader" />
-                        ) : (
-                            <h2 className="show-more-btn-text">Ver mais</h2>
-                        )}
-                    </button>
+                    {!emptyRequest && (
+                        <button
+                            type="button"
+                            className="show-more-btn"
+                            onClick={this.updateRepositoryList}>
+                            {loading ? (
+                                <img className="loader" alt="loader" />
+                            ) : (
+                                <h2 className="show-more-btn-text">Ver mais</h2>
+                            )}
+                        </button>
+                    )}
                 </div>
             </div>
         );


### PR DESCRIPTION
 Resolves #97 
#### Qual o propósito dessa pull request?

Arrumado o bug do botão "Ver mais" aparecendo quando não existem mais projetos

#### O que foi feito?

Adicionado `emptyRequest` ao state, que valida a existência de projetos vindos do request.

#### Como suas mudanças podem ser testadas?
Clicando no botão `Ver mais` até o momento que o botão não apareça mais


#### Screenshots ou exemplos de uso
![vermais](https://user-images.githubusercontent.com/7442967/66681314-dcef9500-ec48-11e9-94c3-c514f0caba23.gif)

#### Tipo de mudanças
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] Nova feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Requires change to documentation, which has been updated accordingly.
