### PR TITLE
Renomeia arquivos conflituosos por serem iguais em case insensitive

### DIFF
--- a/src/components/team/TeamMember.js
+++ b/src/components/team/TeamMember.js
@@ -4,7 +4,7 @@ import React from 'react';
 import type { MemberProps } from './member';
 import './teamPage.css';
 
-const Member = ({ name, urlGithub }: MemberProps) => (
+const TeamMember = ({ name, urlGithub }: MemberProps) => (
     <div className="member">
         <a href={urlGithub}>
             <img
@@ -17,4 +17,4 @@ const Member = ({ name, urlGithub }: MemberProps) => (
     </div>
 );
 
-export default Member;
+export default TeamMember;

--- a/src/components/team/TeamPage.js
+++ b/src/components/team/TeamPage.js
@@ -1,14 +1,14 @@
 // @flow
 
 import React from 'react';
-import Member from './Member';
+import TeamMember from './TeamMember';
 import members from '../../../data/equipe.json';
 import './teamPage.css';
 
 const renderMembers = () =>
     members.map(member => (
         <li>
-            <Member {...member} />
+            <TeamMember {...member} />
         </li>
     ));
 


### PR DESCRIPTION
<!-- Issue relacionada -->

#### Qual o propósito dessa pull request?

Os arquivos `member.js` e `Member.js`, que estavam no mesmo diretório, estavam dando conflito no Git, no Windows, por serem iguais em case insensitive. É melhor considerar que nomes de arquivo são case insensitive, para evitar problemas.

#### O que foi feito?

Renomar um dos arquivos para `TeamMember.js`

#### Como suas mudanças podem ser testadas?

#### Screenshots ou exemplos de uso
<!-- Se aplicável -->

#### Tipo de mudanças

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] Nova feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Requires change to documentation, which has been updated accordingly.
