### PR TITLE
Adiciona dotenv-webpack na configuração do webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "babel-eslint": "^10.0.1",
         "babel-loader": "^8.0.4",
         "css-loader": "^1.0.1",
+        "dotenv-webpack": "^1.7.0",
         "eslint": "^5.8.0",
         "eslint-config-airbnb": "^17.1.0",
         "eslint-config-prettier": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-const webpack = require('webpack');
 const path = require('path');
+const Dotenv = require('dotenv-webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
@@ -54,7 +54,7 @@ const config = {
         new MiniCssExtractPlugin({
             filename: 'style.[contenthash].css',
         }),
-        new webpack.EnvironmentPlugin({ ...process.env }),
+        new Dotenv(),
     ],
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,9 @@ const config = {
         new MiniCssExtractPlugin({
             filename: 'style.[contenthash].css',
         }),
-        new Dotenv(),
+        new Dotenv({
+            systemvars: true,
+        }),
     ],
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,6 +2023,25 @@ domutils@^2.0.0:
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
 
+dotenv-defaults@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz#441cf5f067653fca4bbdce9dd3b803f6f84c585d"
+  integrity sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==
+  dependencies:
+    dotenv "^6.2.0"
+
+dotenv-webpack@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz#4384d8c57ee6f405c296278c14a9f9167856d3a1"
+  integrity sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==
+  dependencies:
+    dotenv-defaults "^1.0.2"
+
+dotenv@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
+  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -4712,12 +4731,7 @@ react-error-overlay@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
 
-react-is@^16.8.1:
-  version "16.10.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
-  integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
-
-react-is@^16.8.6:
+react-is@^16.8.1, react-is@^16.8.6:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==


### PR DESCRIPTION
Este PR depende de #110 

#### Qual o propósito dessa pull request?

Com uma mudança recente, a aplicação em modo `development` não está conseguindo ler as variáveis de ambiente do arquivo `.env`. Este PR corrige este comportamento.

#### O que foi feito?

A dependência [dotenv-webpack](https://github.com/mrsteele/dotenv-webpack) foi adicionada. Esta ferramenta irá ler as variáveis de ambiente do arquivo `.env` e as expor para a aplicação JS.

#### Como suas mudanças podem ser testadas?

Aparentemente o `dotenv-webpack` repassa as variáveis de ambiente já existentes, independente do arquivo `.env`, então creio que em produção irá funcionar.

#### Screenshots ou exemplos de uso
<!-- Se aplicável -->

#### Tipo de mudanças

<!-- Marque com um 'x' os tipos de mudanças realizadas -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] Nova feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Requires change to documentation, which has been updated accordingly.
