### PR TITLE
Nomes e fotos de contribuidores redirecionam para o perfil

### DIFF
--- a/src/components/hacktoberfest/Ranking.css
+++ b/src/components/hacktoberfest/Ranking.css
@@ -35,3 +35,7 @@ td {
 th {
     padding: 10px;
 }
+
+.contributor-name:hover {
+    color: #3ab7f1;
+}

--- a/src/components/hacktoberfest/Ranking.js
+++ b/src/components/hacktoberfest/Ranking.js
@@ -58,20 +58,31 @@ const Ranking = () => {
                     <th>PRs mergeados</th>
                 </tr>
                 {!loading &&
-                    data.search.nodes.map((el, i) => (
-                        <tr>
-                            <td>
-                                <img
-                                    className="avatar"
-                                    alt={el.login}
-                                    src={el.avatarUrl}
-                                />
-                            </td>
-                            <td>{el.login}</td>
-                            <td>{contributions[i].openPrs}</td>
-                            <td>{contributions[i].mergedPrs}</td>
-                        </tr>
-                    ))}
+                    data.search.nodes.map((el, i) => {
+                        const profileUrl = `https://github.com/${el.login}`;
+                        return (
+                            <tr>
+                                <td>
+                                    <a href={profileUrl}>
+                                        <img
+                                            className="avatar"
+                                            alt={el.login}
+                                            src={el.avatarUrl}
+                                        />
+                                    </a>
+                                </td>
+                                <td>
+                                    <a
+                                        className="contributor-name"
+                                        href={profileUrl}>
+                                        {el.login}
+                                    </a>
+                                </td>
+                                <td>{contributions[i].openPrs}</td>
+                                <td>{contributions[i].mergedPrs}</td>
+                            </tr>
+                        );
+                    })}
             </table>
             {loading && (
                 <div className="loading">


### PR DESCRIPTION
<!-- Issue relacionada -->

#### Qual o propósito dessa pull request?

<!--- Descreva o problema ou a feature que está sendo proposta aqui. -->
Eu queria dar uma olhada nos perfis do povo e não achei muito prático copiar e colar os nomes

#### O que foi feito?

<!--- Descreva em detalhes como você implementou a solução -->
Envolvi o nome e a foto em tags `<a>` e adicionei a propriedade `href` com o link para o perfil. Também criei uma classe no css para ficar mais claro que o elemento é clicável

#### Como suas mudanças podem ser testadas?
Clicando no nome do povo :slightly_smiling_face: 

#### Screenshots ou exemplos de uso
<!-- Se aplicável -->
![image](https://user-images.githubusercontent.com/25506387/67151633-266e5e80-f29f-11e9-977c-9b1167d78822.png)

#### Tipo de mudanças

<!-- Marque com um 'x' os tipos de mudanças realizadas -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] Nova feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Requires change to documentation, which has been updated accordingly.
