### PR TITLE
Renderiza emojis no card de repositório

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "ramda": "^0.26.1",
         "react": "^16.10.2",
         "react-dom": "^16.10.2",
+        "react-emoji-render": "^1.0.0",
         "react-markdown": "^4.2.2",
         "react-router-dom": "^4.3.1",
         "react-tooltip": "^3.11.1"

--- a/src/components/commons/repository/RepositoryCard.js
+++ b/src/components/commons/repository/RepositoryCard.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import ReactTooltip from 'react-tooltip';
+import Emoji from 'react-emoji-render';
 import type { Repository } from './repository';
 
 import './Repository.css';
@@ -58,7 +59,7 @@ const RepositoryCard = ({ repository }: RepositoryProps) => {
                     <h6 className="repository-owner">{owner}</h6>
                 </header>
                 <p className="repository-description">
-                    {repository.description}
+                    <Emoji text={repository.description} />
                 </p>
                 <RepositoryStats
                     className="repository-stats"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2213,6 +2213,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-regex@^6.4.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+  integrity sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==
+
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -3361,7 +3366,7 @@ interpret@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -3788,6 +3793,16 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3:
   version "4.17.15"
@@ -4727,7 +4742,7 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4890,6 +4905,17 @@ react-dom@^16.10.2:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.16.2"
+
+react-emoji-render@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-emoji-render/-/react-emoji-render-1.0.0.tgz#696a6a2b3fa6a5ea1e5c186ccd9cbf9232d9b638"
+  integrity sha512-14iNQ1bOqijkIwfmuYMnG0lew2GJhRmSEPEYi7Dc3RDgklaXXwbLB0bmJF/0LUpDH1hy3I1H3EyrKb//FdwCmg==
+  dependencies:
+    classnames "^2.2.5"
+    emoji-regex "^6.4.1"
+    lodash.flatten "^4.4.0"
+    prop-types "^15.5.8"
+    string-replace-to-array "^1.0.1"
 
 react-error-overlay@^5.1.0:
   version "5.1.6"
@@ -5610,6 +5636,15 @@ stream-http@^2.7.2:
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+
+string-replace-to-array@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-replace-to-array/-/string-replace-to-array-1.0.3.tgz#c93eba999a5ee24d731aebbaf5aba36b5f18f7bf"
+  integrity sha1-yT66mZpe4k1zGuu69auja18Y978=
+  dependencies:
+    invariant "^2.2.1"
+    lodash.flatten "^4.2.0"
+    lodash.isstring "^4.0.1"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### Qual o propósito dessa pull request?

Em uma época na qual palavras não são suficientes, emojis surgiram para suprir as necessidades comunicativas da sociedade. Muitos projetos fazem uso de emojis em suas descrições, seja para ajudar a compreender seus propósitos, seja para chamar atenção do usuário. Entretanto, os emojis não estavam sendo renderizados nos cards dos repositórios, impossibilitando que a mensagem representada em cada emoji fosse passada ao usuário do IssueAi. :cry: 

#### O que foi feito?

Adicionei um pacote chamado `react-emoji-render` que renderiza emojis passados como texto e utilizei o componente principal do pacote no campo de descrição dos cards de repositórios.

#### Screenshots ou exemplos de uso

##### Antes...

![Antes](https://user-images.githubusercontent.com/20714148/67172012-066a9800-f390-11e9-948e-b0d2826cf134.png)

##### Agora!
![Depois](https://user-images.githubusercontent.com/20714148/67172018-0cf90f80-f390-11e9-9ab4-9afee46a72d8.png)

#### Tipo de mudanças

<!-- Marque com um 'x' os tipos de mudanças realizadas -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] Nova feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Requires change to documentation, which has been updated accordingly.